### PR TITLE
feat: HT brand theme (teal + purple)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   pull_request: {}
-  push: { branches: [main] }
+  push: { branches: [main, ht] }
 
 jobs:
   build-test:

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -1,0 +1,22 @@
+name: Fork Sync
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_rebase:
+        description: 'Only sync main, skip rebase of ht'
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    uses: heiervang-technologies/.github/.github/workflows/fork-sync-reusable.yml@main
+    with:
+      upstream_repo: 'openai/codex'
+      upstream_branch: 'main'
+      fork_branch: 'ht'
+      skip_rebase: ${{ inputs.skip_rebase || false }}
+    secrets:
+      gh_pat: ${{ secrets.HAI_GH_PAT }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# HT Fork Management Guide
+
+This document describes how Heiervang Technologies maintains forks of upstream open-source projects.
+
+For the full guide, see the [HT Fork Management Guide](https://github.com/orgs/heiervang-technologies/discussions/3).
+
+## Branch Structure
+
+Each fork has two key branches:
+
+| Branch | Purpose | Default? |
+|--------|---------|----------|
+| **`ht`** | HT-specific changes on top of upstream | **Yes** (default branch) |
+| **`main`** | Clean mirror of upstream `main` | No |
+
+### `main` — Upstream Mirror
+
+- Always a clean fast-forward of the upstream `main` branch
+- **Never** commit HT-specific changes to `main`
+- Enable GitHub's "Sync fork" button or use `git fetch upstream && git merge --ff-only upstream/main`
+- Used as the merge base when syncing upstream changes into `ht`
+
+### `ht` — Default Branch
+
+- Contains all HT-specific features, fixes, and configuration on top of `main`
+- Set as the repo's **default branch** on GitHub so that clones, PRs, and the README all reference it
+- All PRs target `ht` unless they're upstream contributions
+
+## Syncing with Upstream
+
+When upstream `main` advances:
+
+```bash
+# 1. Update local main
+git checkout main
+git fetch upstream
+git merge --ff-only upstream/main
+git push origin main
+
+# 2. Rebase ht onto updated main
+git checkout ht
+git rebase main
+
+# 3. Resolve any conflicts, then force-push
+git push --force-with-lease origin ht
+```
+
+## Feature Development
+
+1. Create a feature branch from `ht`:
+   ```bash
+   git checkout -b feat/my-feature ht
+   ```
+2. Develop, commit, push
+3. Open a PR targeting `ht`
+4. Squash-merge the PR
+5. Delete the feature branch after merge
+
+## Commit Standards
+
+- Use [conventional commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `chore:`)
+- Maintain clean, linear history — no merge commits from sync operations
+- One commit per feature or logical change
+
+## Questions & Discussion
+
+For all inquiries about this fork, use the [HT Discussions page](https://github.com/orgs/heiervang-technologies/discussions).
+
+---
+
+## Upstream Contributing
+
+For non-fork-specific changes, follow the [upstream contribution guidelines](./docs/contributing.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
+<h1 align="center">ht-codex</h1>
+
 <p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
+
+<p align="center">
+    <em>Heiervang Technologies fork of <a href="https://github.com/openai/codex">Codex CLI</a></em>
+</p>
+
+<p align="center">
+    <a href="https://github.com/orgs/heiervang-technologies/discussions">HT Discussions</a> |
+    <a href="https://github.com/orgs/heiervang-technologies/discussions/3">Fork Management Guide</a> |
+    <a href="https://github.com/openai/codex">Upstream Project</a>
+</p>
+
 <p align="center">
   <img src="https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />
 </p>
@@ -7,6 +20,27 @@
 If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="https://developers.openai.com/codex/ide">install in your IDE.</a>
 </br>If you want the desktop app experience, run <code>codex app</code> or visit <a href="https://chatgpt.com/codex?app-landing-page=true">the Codex App page</a>.
 </br>If you are looking for the <em>cloud-based agent</em> from OpenAI, <strong>Codex Web</strong>, go to <a href="https://chatgpt.com/codex">chatgpt.com/codex</a>.</p>
+
+---
+
+## HT Fork Changes
+
+This is the **Heiervang Technologies** fork of [Codex CLI](https://github.com/openai/codex). The `main` branch is kept as a clean fast-forward mirror of upstream. All HT-specific changes live on the `ht` branch.
+
+### What's different from upstream
+
+| Change | Description | Contributed back? |
+|--------|-------------|:-----------------:|
+| HT fork docs | This section, CONTRIBUTING.md with fork management guide | No |
+
+### Branch strategy
+
+- **`main`** — Clean mirror of upstream. Never modified directly.
+- **`ht`** — Default branch. Contains all HT-specific additions rebased on top of `main`.
+
+For questions, feature requests, or bug reports related to this fork, please use the [HT Discussions page](https://github.com/orgs/heiervang-technologies/discussions). For upstream issues, use the [upstream repository](https://github.com/openai/codex/issues).
+
+See the [HT Fork Management Guide](https://github.com/orgs/heiervang-technologies/discussions/3) for our branch conventions, sync workflow, and contribution process.
 
 ---
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2637,9 +2637,9 @@ impl ChatComposer {
             .map(|(idx, _)| {
                 let label = local_image_label_text(idx + 1);
                 if self.selected_remote_image_index == Some(idx) {
-                    label.cyan().reversed().into()
+                    label.fg(crate::brand::PRIMARY).reversed().into()
                 } else {
-                    label.cyan().into()
+                    label.fg(crate::brand::PRIMARY).into()
                 }
             })
             .collect()

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -103,7 +103,9 @@ impl CollaborationModeIndicator {
         let label = self.label(show_cycle_hint);
         match self {
             CollaborationModeIndicator::Plan => Span::from(label).magenta(),
-            CollaborationModeIndicator::PairProgramming => Span::from(label).cyan(),
+            CollaborationModeIndicator::PairProgramming => {
+                Span::from(label).fg(crate::brand::PRIMARY)
+            }
             CollaborationModeIndicator::Execute => Span::from(label).dim(),
         }
     }

--- a/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -297,7 +297,7 @@ fn apply_row_state_style(lines: &mut [Line<'static>], selected: bool, is_disable
     if selected {
         for line in lines.iter_mut() {
             line.spans.iter_mut().for_each(|span| {
-                span.style = Style::default().fg(Color::Cyan).bold();
+                span.style = Style::default().fg(crate::brand::PRIMARY).bold();
             });
         }
     }
@@ -721,7 +721,7 @@ pub(crate) fn render_rows_single_line(
         let mut full_line = build_full_line(row, desc_col);
         if Some(i) == state.selected_idx && !row.is_disabled {
             full_line.spans.iter_mut().for_each(|span| {
-                span.style = Style::default().fg(Color::Cyan).bold();
+                span.style = Style::default().fg(crate::brand::PRIMARY).bold();
             });
         }
         if row.is_disabled {

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -1383,7 +1383,7 @@ impl TextArea {
                 }
                 let styled = &self.text[overlap_start..overlap_end];
                 let x_off = self.text[line_range.start..overlap_start].width() as u16;
-                let style = Style::default().fg(Color::Cyan);
+                let style = Style::default().fg(crate::brand::PRIMARY);
                 buf.set_string(area.x + x_off, y, styled, style);
             }
         }

--- a/codex-rs/tui/src/brand.rs
+++ b/codex-rs/tui/src/brand.rs
@@ -1,0 +1,13 @@
+//! HT brand accent colors.
+//!
+//! Primary: light teal.  Secondary: purple.
+//! These are used throughout the TUI wherever the upstream codebase used
+//! `Color::Cyan` as a generic accent.
+
+use ratatui::style::Color;
+
+/// Primary accent — light teal.
+pub const PRIMARY: Color = Color::Rgb(0x4D, 0xB6, 0xAC); // #4DB6AC
+
+/// Secondary accent — purple (used where a contrasting accent is helpful).
+pub const SECONDARY: Color = Color::Rgb(0x7E, 0x57, 0xC2); // #7E57C2

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -294,7 +294,7 @@ impl HistoryCell for UserHistoryCell {
             .max(1);
 
         let style = user_message_style();
-        let element_style = style.fg(Color::Cyan);
+        let element_style = style.fg(crate::brand::PRIMARY);
 
         let wrapped_remote_images = if self.remote_image_urls.is_empty() {
             None

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -66,6 +66,7 @@ mod ascii_animation;
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
 mod audio_device;
 mod bottom_pane;
+mod brand;
 mod chatwidget;
 mod cli;
 mod clipboard_paste;

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -37,6 +37,7 @@ struct MarkdownStyles {
 
 impl Default for MarkdownStyles {
     fn default() -> Self {
+        use crate::brand;
         use ratatui::style::Stylize;
 
         Self {
@@ -46,14 +47,14 @@ impl Default for MarkdownStyles {
             h4: Style::new().italic(),
             h5: Style::new().italic(),
             h6: Style::new().italic(),
-            code: Style::new().cyan(),
+            code: Style::new().fg(brand::PRIMARY),
             emphasis: Style::new().italic(),
             strong: Style::new().bold(),
             strikethrough: Style::new().crossed_out(),
-            ordered_list_marker: Style::new().light_blue(),
+            ordered_list_marker: Style::new().fg(brand::SECONDARY),
             unordered_list_marker: Style::new(),
-            link: Style::new().cyan().underlined(),
-            blockquote: Style::new().green(),
+            link: Style::new().fg(brand::PRIMARY).underlined(),
+            blockquote: Style::new().fg(brand::SECONDARY),
         }
     }
 }

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -535,7 +535,7 @@ impl AuthModeWidget {
                     .title("API key")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::Cyan)),
+                    .border_style(Style::default().fg(crate::brand::PRIMARY)),
             )
             .render(input_area, buf);
 

--- a/codex-rs/tui/src/oss_selection.rs
+++ b/codex-rs/tui/src/oss_selection.rs
@@ -243,7 +243,7 @@ impl WidgetRef for &OssSelectionWidget<'_> {
             .enumerate()
             .map(|(idx, opt)| {
                 let style = if idx == self.selected_option {
-                    Style::new().bg(Color::Cyan).fg(Color::Black)
+                    Style::new().bg(crate::brand::PRIMARY).fg(Color::Black)
                 } else {
                     Style::new().bg(Color::DarkGray)
                 };

--- a/codex-rs/tui/src/selection_list.rs
+++ b/codex-rs/tui/src/selection_list.rs
@@ -27,7 +27,7 @@ pub(crate) fn selection_option_row_with_dim(
         format!("  {}. ", index + 1)
     };
     let style = if is_selected {
-        Style::default().cyan()
+        Style::default().fg(crate::brand::PRIMARY)
     } else if dim {
         Style::default().dim()
     } else {


### PR DESCRIPTION
## Summary
- Adds `brand.rs` module with centralized accent colors: primary light teal (`#4DB6AC`) and secondary purple (`#7E57C2`)
- Replaces hardcoded cyan accent with brand colors in key UI elements:
  - Markdown: code spans, links (teal), blockquotes, ordered list markers (purple)
  - Selection highlights (lists, popups, OSS picker)
  - Onboarding auth border
  - Footer collaboration mode indicator
  - Textarea slash command highlighting
  - Chat composer image labels

## Test plan
- [x] `cargo check` clean
- [ ] Visual verification of teal/purple theming in TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)