### PR TITLE
Fix fork sync workflow token

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -10,6 +10,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   sync:
     uses: heiervang-technologies/.github/.github/workflows/fork-sync-reusable.yml@main
@@ -19,4 +23,4 @@ jobs:
       fork_branch: 'ht'
       skip_rebase: ${{ github.event.inputs.skip_rebase == 'true' }}
     secrets:
-      gh_pat: ${{ secrets.HAI_GH_PAT }}
+      gh_pat: ${{ github.token }}


### PR DESCRIPTION
## Summary

Fix the scheduled `Fork Sync` workflow by using the repository `GITHUB_TOKEN` for the reusable sync workflow instead of `secrets.HAI_GH_PAT`.

## Root Cause

The latest scheduled run fast-forwarded `main` successfully, then failed pushing back to `heiervang-technologies/ht-codex`:

```text
remote: Permission to heiervang-technologies/ht-codex.git denied to marksverdhai.
fatal: unable to access 'https://github.com/heiervang-technologies/ht-codex/': The requested URL returned error: 403
```

The wrapper was passing `HAI_GH_PAT`, which resolves to a user token without write access for this repo. The reusable workflow expects a token with `contents:write` and `issues:write`, so this PR grants those minimal permissions to the repo token and passes `github.token` as `gh_pat`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fork-sync.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/fork-sync.yml`

## Notes

After merge, rerun `Fork Sync` manually or wait for the next scheduled run to confirm the push step succeeds.
