### PR TITLE
Use fork sync default token

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -22,5 +22,3 @@ jobs:
       upstream_branch: 'main'
       fork_branch: 'ht'
       skip_rebase: ${{ github.event.inputs.skip_rebase == 'true' }}
-    secrets:
-      gh_pat: ${{ github.token }}


### PR DESCRIPTION
## Summary

Remove the explicit `gh_pat: ${{ github.token }}` secret mapping from the `Fork Sync` caller.

## Why

The reusable workflow in `heiervang-technologies/.github` now defaults to its own `GITHUB_TOKEN`, so callers do not need to pass a token unless they intentionally want a PAT override. Passing `github.token` through `secrets:` evaluated to an empty token during verification and caused checkout to fail before the reusable fallback existed.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fork-sync.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/fork-sync.yml`
