### PR TITLE
Use workflow-capable fork sync token

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -22,3 +22,5 @@ jobs:
       upstream_branch: 'main'
       fork_branch: 'ht'
       skip_rebase: ${{ github.event.inputs.skip_rebase == 'true' }}
+    secrets:
+      gh_pat: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

Pass the org `GH_TOKEN` PAT into the fork sync reusable workflow.

## Why

The reusable workflow can now default to `GITHUB_TOKEN`, but the `ht-codex` upstream sync includes changes to `.github/workflows/*`. GitHub rejects workflow-file updates from the repository `GITHUB_TOKEN`:

```text
refusing to allow a GitHub App to create or update workflow `.github/workflows/bazel.yml` without `workflows` permission
```

The previous `HAI_GH_PAT` secret resolved to a token that lacked push access to this repo. The org-wide `GH_TOKEN` secret is available to this repo and should be the workflow-capable PAT for this sync path.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fork-sync.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/fork-sync.yml`
