### PR TITLE
Remove invalid fork sync PAT mapping

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -22,5 +22,3 @@ jobs:
       upstream_branch: 'main'
       fork_branch: 'ht'
       skip_rebase: ${{ github.event.inputs.skip_rebase == 'true' }}
-    secrets:
-      gh_pat: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

Remove the `secrets.GH_TOKEN` mapping from the Fork Sync caller.

## Why

Manual verification showed this org secret is non-empty but unusable for GitHub checkout in `ht-codex`:

```text
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Leaving the mapping active makes the workflow fail before checkout. Without it, the reusable workflow falls back to `GITHUB_TOKEN`, which at least authenticates correctly; a separate workflow-capable PAT still needs to be configured before upstream workflow-file changes can be synced automatically.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fork-sync.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/fork-sync.yml`
